### PR TITLE
Fix internal CI pipelines

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -19,7 +19,7 @@ default:
       command: ["--experimental"]
 
 variables:
-  BUILD_MULTI_ARCH_IMAGES: "false"
+  BUILD_MULTI_ARCH_IMAGES: "true"
 
 stages:
   - image
@@ -32,10 +32,18 @@ stages:
   - scan
   - release
 
+.dist-ubi8:
+  variables:
+    DIST: ubi8
+
 # Define the platform targets
 .platform-amd64:
   variables:
     PLATFORM: linux/amd64
+
+.platform-arm64:
+  variables:
+    PLATFORM: linux/arm64
 
 # Make buildx available as a docker CLI plugin
 .buildx-setup:
@@ -50,6 +58,16 @@ stages:
 
     -  '[[ -n "${SKIP_QEMU_SETUP}" ]] || docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
 
+# Download the regctl binary for use in the release steps
+.regctl-setup:
+  before_script:
+    - export REGCTL_VERSION=v0.6.0
+    - apk add --no-cache curl
+    - mkdir -p bin
+    - curl -sSLo bin/regctl https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64
+    - chmod a+x bin/regctl
+    - export PATH=$(pwd)/bin:${PATH}
+
 # .release forms the base of the deployment jobs which push images to the CI registry.
 # This is extended with the version to be deployed (e.g. the SHA or TAG) and the
 # target os.
@@ -62,7 +80,7 @@ stages:
     # OUT_IMAGE_VERSION is overridden for external releases
     OUT_IMAGE_VERSION: "${CI_COMMIT_SHORT_SHA}"
   before_script:
-    #- !reference [.regctl-setup, before_script]
+    - !reference [.regctl-setup, before_script]
     # We ensure that the OUT_IMAGE_VERSION is set
     - 'echo Version: ${OUT_IMAGE_VERSION} ; [[ -n "${OUT_IMAGE_VERSION}" ]] || exit 1'
     # In the case where we are deploying a different version to the CI_COMMIT_SHA, we
@@ -70,19 +88,20 @@ stages:
     # Note: a leading 'v' is stripped from the version if present
     - apk add --no-cache make bash
   script:
+    # Log in to the "output" registry, tag the image and push the image
     - 'echo "Logging in to CI registry ${CI_REGISTRY}"'
-    - docker login "${CI_REGISTRY}" -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}"
+    - regctl registry login "${CI_REGISTRY}" -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}"
     - '[ ${CI_REGISTRY} = ${OUT_REGISTRY} ] || echo "Logging in to output registry ${OUT_REGISTRY}"'
-    - '[ ${CI_REGISTRY} = ${OUT_REGISTRY} ] || docker login "${OUT_REGISTRY}" -u "${OUT_REGISTRY_USER}" -p "${OUT_REGISTRY_TOKEN}"'
+    - '[ ${CI_REGISTRY} = ${OUT_REGISTRY} ] || regctl registry login "${OUT_REGISTRY}" -u "${OUT_REGISTRY_USER}" -p "${OUT_REGISTRY_TOKEN}"'
 
-    # Since OUT_IMAGE_NAME and OUT_IMAGE_VERSION are set, this will push the CI image to the target
-    - make pull-image
-    - make push-image
+    # Since OUT_IMAGE_NAME and OUT_IMAGE_VERSION are set, this will push the CI image to the
+    # Target
+    - make -f deployments/container/Makefile push-${DIST}
 
 # Define a staging release step that pushes an image to an internal "staging" repository
 # This is triggered for all pipelines (i.e. not only tags) to test the pipeline steps
 # outside of the release process.
-release:staging:
+.release:staging:
   extends:
     - .release
   variables:
@@ -90,8 +109,6 @@ release:staging:
     OUT_REGISTRY_TOKEN: "${CI_REGISTRY_PASSWORD}"
     OUT_REGISTRY: "${CI_REGISTRY}"
     OUT_IMAGE_NAME: "${CI_REGISTRY_IMAGE}/staging/k8s-kata-manager"
-  needs:
-    - image-build
 
 # Define an external release step that pushes an image to an external repository.
 .release:external:
@@ -101,3 +118,10 @@ release:staging:
     - if: $CI_COMMIT_TAG
       variables:
         OUT_IMAGE_VERSION: "${CI_COMMIT_TAG}"
+
+release:staging-ubi8:
+  extends:
+    - .release:staging
+    - .dist-ubi8
+  needs:
+    - image-ubi8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ include:
   - local: '.common-ci.yml'
 
 # Define the image build targets
-image-build:
+.image-build:
   stage: image-build
   variables:
     IMAGE_NAME: "${CI_REGISTRY_IMAGE}"
@@ -28,5 +28,9 @@ image-build:
     - 'echo "Logging in to CI registry ${CI_REGISTRY}"'
     - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
   script:
-    - make build-image
-    - make push-image
+    - make -f deployments/container/Makefile build-${DIST}
+
+image-ubi8:
+  extends:
+    - .image-build
+    - .dist-ubi8

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -30,10 +30,10 @@ variables:
   # On the multi-arch builder we don't need the qemu setup.
   SKIP_QEMU_SETUP: "1"
   # Define the public staging registry
-  STAGING_REGISTRY: registry.gitlab.com/nvidia/cloud-native/k8s-kata-manager/staging
+  STAGING_REGISTRY: ghcr.io/nvidia
   STAGING_VERSION: ${CI_COMMIT_SHORT_SHA}
 
-image-build:
+.image-pull:
   stage: image-build
   variables:
     IN_REGISTRY: "${STAGING_REGISTRY}"
@@ -54,11 +54,18 @@ image-build:
       - job_execution_timeout
       - stuck_or_timeout_failure
   before_script:
+    - !reference [.regctl-setup, before_script]
     - apk add --no-cache make bash
+    - >
+      regctl manifest get ${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION}-ubi8 --list > /dev/null && echo "${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION}-${DIST}" || ( echo "${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION}-${DIST} does not exist" && sleep infinity )
   script:
-    - docker login "${OUT_REGISTRY}" -u "${OUT_REGISTRY_USER}" -p "${OUT_REGISTRY_TOKEN}"
-    - make IMAGE=${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION} pull-image
-    - make IMAGE=${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION} OUT_IMAGE=${OUT_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA} push-image
+    - regctl registry login "${OUT_REGISTRY}" -u "${OUT_REGISTRY_USER}" -p "${OUT_REGISTRY_TOKEN}"
+    - make -f deployments/container/Makefile IMAGE=${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION}-${DIST} OUT_IMAGE=${OUT_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA}-${DIST} push-${DIST}
+
+image-ubi8:
+  extends:
+    - .image-pull
+    - .dist-ubi8
 
 # The .scan step forms the base of the image scan operation performed before releasing
 # images.
@@ -66,7 +73,7 @@ image-build:
   stage: scan
   image: "${PULSE_IMAGE}"
   variables:
-    IMAGE: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}"
+    IMAGE: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}-${DIST}"
     IMAGE_ARCHIVE: "k8s-kata-manager.tar"
   except:
     variables:
@@ -95,7 +102,14 @@ image-build:
 scan-amd64:
   extends:
     - .scan
+    - .dist-ubi8
     - .platform-amd64
+
+scan-arm64:
+  extends:
+    - .scan
+    - .dist-ubi8
+    - .platform-arm64
 
 # Define the external release helpers
 .release:ngc:
@@ -111,6 +125,7 @@ scan-amd64:
 
 # Define the external release targets
 # Release to NGC
-release:ngc:
+release:ngc-ubi8:
   extends:
     - .release:ngc
+    - .dist-ubi8


### PR DESCRIPTION
With this change, the internal pipelines now pull images from ghcr.io

For reference: https://gitlab-master.nvidia.com/dl/container-dev/k8s-kata-manager/-/pipelines/14350090