### PR TITLE
Update .release:staging variables to stage in nvstaging

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -82,8 +82,8 @@ stages:
     OUT_IMAGE_VERSION: "${CI_COMMIT_SHORT_SHA}"
   before_script:
     - !reference [.regctl-setup, before_script]
-    # We ensure that the OUT_IMAGE_VERSION is set
-    - 'echo Version: ${OUT_IMAGE_VERSION} ; [[ -n "${OUT_IMAGE_VERSION}" ]] || exit 1'
+    # We ensure that the OUT_IMAGE_VERSION and OUT_IMAGE_NAME is set
+    - 'echo "Version: ${OUT_IMAGE_VERSION}, Image: ${OUT_IMAGE_NAME}" ; [[ -n "${OUT_IMAGE_VERSION}" && -n "${OUT_IMAGE_NAME}" ]] || exit 1'
     # In the case where we are deploying a different version to the CI_COMMIT_SHA, we
     # need to tag the image.
     # Note: a leading 'v' is stripped from the version if present
@@ -106,10 +106,10 @@ stages:
   extends:
     - .release
   variables:
-    OUT_REGISTRY_USER: "${CI_REGISTRY_USER}"
-    OUT_REGISTRY_TOKEN: "${CI_REGISTRY_PASSWORD}"
-    OUT_REGISTRY: "${CI_REGISTRY}"
-    OUT_IMAGE_NAME: "${CI_REGISTRY_IMAGE}/staging/k8s-kata-manager"
+    OUT_REGISTRY_USER: "${NGC_REGISTRY_USER}"
+    OUT_REGISTRY_TOKEN: "${NGC_REGISTRY_TOKEN}"
+    OUT_REGISTRY: "${NGC_REGISTRY}"
+    OUT_IMAGE_NAME: "${NGC_REGISTRY_STAGING_IMAGE_NAME}"
 
 # Define an external release step that pushes an image to an external repository.
 .release:external:


### PR DESCRIPTION
Updates the .release:staging variables to stage images in nvstaging. These changes are needed for the new NGC Publishing workflow.