### PR TITLE
Updated the gitlab pipeline to use correct 'push-image' make target

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -97,7 +97,7 @@ stages:
 
     # Since OUT_IMAGE_NAME and OUT_IMAGE_VERSION are set, this will push the CI image to the
     # Target
-    - make -f deployments/container/Makefile push-${DIST}
+    - make -f deployments/container/Makefile push-image
 
 # Define a staging release step that pushes an image to an internal "staging" repository
 # This is triggered for all pipelines (i.e. not only tags) to test the pipeline steps

--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -60,7 +60,7 @@ variables:
       regctl manifest get ${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION} --list > /dev/null && echo "${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION}" || ( echo "${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION} does not exist" && sleep infinity )
   script:
     - regctl registry login "${OUT_REGISTRY}" -u "${OUT_REGISTRY_USER}" -p "${OUT_REGISTRY_TOKEN}"
-    - make -f deployments/container/Makefile IMAGE=${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION} OUT_IMAGE=${OUT_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA} push-${DIST}
+    - make -f deployments/container/Makefile IMAGE=${IN_REGISTRY}/${IN_IMAGE_NAME}:${IN_VERSION} OUT_IMAGE=${OUT_IMAGE_NAME}:${CI_COMMIT_SHORT_SHA} push-image
 
 image-ubi9:
   extends:


### PR DESCRIPTION
Updated Pipeline CI definitions to push-image based on our distroless container changes. Tested here: https://gitlab-master.nvidia.com/dl/container-dev/k8s-kata-manager/-/pipelines/29598684