### PR TITLE
Build multiarch images on native GitHub runners

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -15,13 +15,10 @@
 name: Golang
 
 on:
-  pull_request:
-    branches:
-      - main
-      - release-*
   push:
     branches:
       - main
+      - "pull-request/[0-9]+"
       - release-*
 
 jobs:

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -16,21 +16,20 @@
 name: Image
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-    branches:
-      - main
-      - release-*
   push:
     branches:
       - main
+      - "pull-request/[0-9]+"
       - release-*
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    runs-on: linux-${{ matrix.arch }}-cpu4
     steps:
       - uses: actions/checkout@v4
         name: Check out code
@@ -52,11 +51,6 @@ jobs:
             GENERATE_ARTIFACTS="true"
           fi
           echo "PUSH_ON_BUILD=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
-          echo "BUILD_MULTI_ARCH_IMAGES=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -66,7 +60,48 @@ jobs:
       - name: Build image
         env:
           IMAGE_NAME: ghcr.io/${LOWERCASE_REPO_OWNER}/k8s-kata-manager
-          VERSION: ${COMMIT_SHORT_SHA}
+          VERSION: ${COMMIT_SHORT_SHA}-${{ matrix.arch }}
+          DOCKER_BUILD_PLATFORM_OPTIONS: "--platform=linux/${{ matrix.arch }}"
         run: |
           echo "${VERSION}"
           make -f deployments/container/Makefile build-image
+
+  create-manifest:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Check out code
+      - name: Calculate build vars
+        id: vars
+        run: |
+          echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+          echo "LOWERCASE_REPO_OWNER=$(echo "${GITHUB_REPOSITORY_OWNER}" | awk '{print tolower($0)}')" >> $GITHUB_ENV
+
+          GENERATE_ARTIFACTS="false"
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            GENERATE_ARTIFACTS="false"
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+            GENERATE_ARTIFACTS="true"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            GENERATE_ARTIFACTS="true"
+          fi
+
+          echo "GENERATE_ARTIFACTS=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
+      - name: Login to GitHub Container Registry
+        if: ${{ env.GENERATE_ARTIFACTS == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Manifest
+        if: ${{ env.GENERATE_ARTIFACTS == 'true' }}
+        env:
+          MULTIARCH_IMAGE: ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/k8s-kata-manager:${{ env.COMMIT_SHORT_SHA }}
+        run: |
+          docker manifest create \
+            ${MULTIARCH_IMAGE} \
+            ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/k8s-kata-manager:${{ env.COMMIT_SHORT_SHA }}-amd64 \
+            ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/k8s-kata-manager:${{ env.COMMIT_SHORT_SHA }}-arm64
+          docker manifest push ${MULTIARCH_IMAGE}

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -14,10 +14,6 @@
 
 BUILD_MULTI_ARCH_IMAGES ?= no
 DOCKER ?= docker
-BUILDX  =
-ifeq ($(BUILD_MULTI_ARCH_IMAGES),true)
-BUILDX = buildx
-endif
 MKDIR    ?= mkdir
 
 ##### Global variables #####
@@ -53,8 +49,7 @@ build-image: DOCKERFILE = $(CURDIR)/deployments/container/Dockerfile
 
 # Use a generic build target to build the relevant images
 $(IMAGE_TARGETS):
-	DOCKER_BUILDKIT=1 \
-		$(DOCKER) $(BUILDX) build --pull \
+	$(DOCKER) build --pull \
 		$(DOCKER_BUILD_OPTIONS) \
 		$(DOCKER_BUILD_PLATFORM_OPTIONS) \
 		--tag $(IMAGE) \

--- a/deployments/container/multi-arch.mk
+++ b/deployments/container/multi-arch.mk
@@ -15,6 +15,6 @@
 PUSH_ON_BUILD ?= false
 ATTACH_ATTESTATIONS ?= false
 DOCKER_BUILD_OPTIONS = --output=type=image,push=$(PUSH_ON_BUILD) --provenance=$(ATTACH_ATTESTATIONS) --sbom=$(ATTACH_ATTESTATIONS)
-DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64,linux/arm64
+DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64,linux/arm64
 
 $(BUILD_TARGETS): image

--- a/deployments/container/native-only.mk
+++ b/deployments/container/native-only.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 PUSH_ON_BUILD ?= false
-DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
+DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64
 
 ifeq ($(PUSH_ON_BUILD),true)
 $(BUILD_TARGETS): image


### PR DESCRIPTION
This commit makes the following changes:

1. Builds multiarch images for non-release commits/PRs, in addition to released versions.
2. Runs the docker build for an arch on the respective GitHub runner (e.g. a linux/amd64 docker image will be built on a linux/amd64 runner). This native build reduces build times due to not requiring emulation.
3. Removes explicit use of buildx for docker build. Buildx is now the default builder in Docker. Also removes the related QEMU setup.