### PR TITLE
disable attestations in single arch docker build by default

### DIFF
--- a/deployments/container/native-only.mk
+++ b/deployments/container/native-only.mk
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 PUSH_ON_BUILD ?= false
-DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64
+ATTACH_ATTESTATIONS ?= false
+DOCKER_BUILD_OPTIONS = --output=type=image,push=$(PUSH_ON_BUILD) --provenance=$(ATTACH_ATTESTATIONS) --sbom=$(ATTACH_ATTESTATIONS)
 
 ifeq ($(PUSH_ON_BUILD),true)
 $(BUILD_TARGETS): image


### PR DESCRIPTION
The new docker engine versions baked into our GH action runners enable provenance by default which lead to our single arch docker images being built as a manifest list. This prevents us from actually stitching together a multiarch image manifest from two docker images. 