### PR TITLE
Ship static busybox shell in k8s-kata-manager image

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -12,8 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build a static busybox layout: one binary plus applet symlinks (sh, rm,
+# ln, sleep, cat, ...) so PATH-resolved commands in init-container wrappers
+# and lifecycle hooks keep working on the non-*-dev* distroless base.
+FROM debian:trixie-slim AS shell
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends busybox-static \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir /busybox \
+ && cp /bin/busybox /busybox/busybox \
+ && /busybox/busybox --install -s /busybox
+
 # This Dockerfile is also used to define the golang version used in this project
 # This allows dependabot to manage this version in addition to other images.
-FROM nvcr.io/nvidia/distroless/cc:v4.0.0-dev
+FROM nvcr.io/nvidia/distroless/cc:v4.0.6
+
+COPY --from=shell /busybox /busybox
+USER 0:0
+RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox
 
 ENTRYPOINT ["/busybox/sh", "-c", "while true; do sleep 86400; done"]

--- a/deployments/container/Dockerfile.deprecated
+++ b/deployments/container/Dockerfile.deprecated
@@ -43,12 +43,25 @@ ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"
 RUN make PREFIX=/artifacts cmds
 
-FROM nvcr.io/nvidia/distroless/go:v3.2.1-dev
+# Build a static busybox layout: one binary plus applet symlinks (sh, rm,
+# ln, sleep, cat, ...) so PATH-resolved commands in init-container wrappers
+# and lifecycle hooks keep working on the non-*-dev* distroless base.
+FROM debian:trixie-slim AS shell
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends busybox-static \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir /busybox \
+ && cp /bin/busybox /busybox/busybox \
+ && /busybox/busybox --install -s /busybox
+
+FROM nvcr.io/nvidia/distroless/go:v3.2.1
 
 USER 0:0
 
-SHELL ["/busybox/sh", "-c"]
-RUN ln -s /busybox/sh /bin/sh
+COPY --from=shell /busybox /busybox
+RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox
+
 COPY --from=build /artifacts/k8s-kata-manager /usr/bin/k8s-kata-manager
 
 LABEL version="${VERSION}"


### PR DESCRIPTION
Flip the base from `*-dev*` to non-`*-dev*` distroless and source a static busybox from `debian:trixie-slim`. The k8s-kata-manager entrypoint continues to work via `/bin/sh` and busybox applet symlinks layered into the final image.

Updates both `Dockerfile` (the actual build target, per `deployments/container/Makefile:48`) and `Dockerfile.deprecated` so no `-dev` reference remains in the repo.

Part of NVIDIA/cloud-native-team#299.
Resolves #177.